### PR TITLE
Api key features

### DIFF
--- a/holeinfo/src.py
+++ b/holeinfo/src.py
@@ -275,14 +275,14 @@ def main():
         help="Time between refreshes(in seconds)",
     )
     parser.add_argument(
-        "-api",
+        "--api",
         type=str,
         default=None,
         dest="api_key",
         help="API key for pi.hole"
     )
     parser.add_argument(
-        "-ip",
+        "--ip",
         type=str,
         default="pi.hole",
         dest="ip",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = 'Commandline tool to display pi-hole statistics to be' + \
 
 setup(
         name='holeinfo',
-        version='1.2',
+        version='2.0',
         author='Manik',
         author_email='me@manik.cc',
         url='https://github.com/mnk400/holeinfo',


### PR DESCRIPTION
This will add extra information and actions by using the API key provided by PiHole

- Display top domains 
- Display top clients
- Enable PiHole service
- Disable PiHole service

Upcoming in minor versions
- Ability to permanently store API key without having to re-enter every single time.